### PR TITLE
Switch to rawgithub.com since raw.github.com doesn't work

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ Bullshit.js is a best-of-breed, mission-critical enterprise JavaScript bookmarkl
 To use it, add the following address as a bookmark and click on it when you're on any page that needs translation.
 
 ```js
-javascript:(function(){var d=document,s=d.createElement('script');s.src='https://rawgithub.com/mourner/bullshit.js/master/bullshit.js';d.body.appendChild(s);}())
+javascript:(function(){var d=document,s=d.createElement('script');s.src='https://cdn.rawgit.com/mourner/bullshit.js/ab4953a30a113ff62e00efe38255dbcc54d5abfb/bullshit.js';d.body.appendChild(s);}())
 ```
 
 P.S. Happily accepting pull requests!


### PR DESCRIPTION
raw.gitgub.com only serves plain text so using this snippet in an actual bookmarklet doesn't work. This switches this to rawgithub.com which serves things up correctly.
