### PR TITLE
update ```crypto.currency``` pattern

### DIFF
--- a/src/terms.js
+++ b/src/terms.js
@@ -71,6 +71,7 @@ export default [
     'craftsmanship',
     'critical path',
     'crypto.currency',
+    'crypto(?!graphy).\w+',
     'crm',
     'cross.sell',
     'crowd.?(fund(s?|ed|ing)|sourc(ed|e|ing))',


### PR DESCRIPTION
The previous version matched against cryptocurrency only.
The new version matches against anything that is not cryptography.